### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -2,7 +2,7 @@ name: Build archiving
 
 on:
   push:
-    branches: [ develop, work/add-ci-timeouts ]
+    branches: [ develop ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -9,6 +9,7 @@ jobs:
   build-apk:
     name: Android build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -39,6 +40,7 @@ jobs:
   build-ipa:
     name: iOS build
     runs-on: macos-latest
+    timeout-minutes: 15
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -2,7 +2,7 @@ name: Build archiving
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, work/add-ci-timeouts ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -23,13 +23,23 @@ jobs:
         uses: ./.github/actions/setup-environment
       - name: Build Android application
         id: build-android-app
-        run: flutter build apk --release --build-number=$GITHUB_RUN_NUMBER
+        run: |
+          # Print build info
+          APP_VERSION_NUMBER=$(sed -n 's/.*version: \([0-9\.]*\)\+.*/\1/p' pubspec.yaml)
+          echo "Version number: $APP_VERSION_NUMBER"
+          echo "Build number:   $GITHUB_RUN_NUMBER"
+          echo "artifactVersion=$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
+          # Make build
+          flutter build apk --release --build-number=$GITHUB_RUN_NUMBER
+          # Prepare artifact
+          mkdir artifact
+          mv build/app/outputs/flutter-apk/app-release.apk "artifact/rescado_$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER.apk"
       - name: Archive Android application
         id: archive-android-app
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v2.3.1
         with:
-          name: Android build (zipped apk file, unsigned)
-          path: build/app/outputs/flutter-apk/app-release.apk
+          name: Android build ${{ env.artifactVersion }} (zipped apk file, unsigned)
+          path: artifact/*.apk
       - name: Send status to Slack
         if: failure()
         uses: act10ns/slack@v1.2.2
@@ -55,17 +65,24 @@ jobs:
       - name: Build iOS application
         id: build-ios-app
         run: |
+          # Print build info
+          APP_VERSION_NUMBER=$(sed -n 's/.*version: \([0-9\.]*\)\+.*/\1/p' pubspec.yaml)
+          echo "Version number: $APP_VERSION_NUMBER"
+          echo "Build number:   $GITHUB_RUN_NUMBER"
+          echo "artifactVersion=$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
+          # Make build
           flutter build ios --release --build-number=$GITHUB_RUN_NUMBER --no-codesign
-          mkdir -p Payload
-          cp -r build/ios/iphoneos/Runner.app Payload
-          zip -r -y Payload.zip Payload/Runner.app
-          mv Payload.zip app-release.ipa
+          # Prepare artifact
+          mkdir -p artifact/Payload
+          cp -r build/ios/iphoneos/Runner.app artifact/Payload
+          cd artifact
+          zip -r -y "rescado_$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER.ipa" Payload/Runner.app
       - name: Archive iOS application
         id: archive-ios-app
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v2.3.1
         with:
-          name: iOS build (zipped ipa file, unsigned)
-          path: app-release.ipa
+          name: iOS build ${{ env.artifactVersion }} (zipped ipa file, unsigned)
+          path: artifact/*.ipa
       - name: Send status to Slack
         if: failure()
         uses: act10ns/slack@v1.2.2

--- a/.github/workflows/quality-control.yml
+++ b/.github/workflows/quality-control.yml
@@ -9,6 +9,7 @@ jobs:
   format:
     name: Verify formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -33,6 +34,7 @@ jobs:
   analyze:
     name: Perform analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -58,6 +60,7 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.rescado.mobileapp">
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.INTERNET"/>
   <application
     android:label="Rescado"
     android:name="${applicationName}"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="org.rescado.mobileapp">
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
   <uses-permission android:name="android.permission.INTERNET"/>
   <application
     android:label="Rescado"


### PR DESCRIPTION
This adds a 15 minute max runtime for each job after which it will fail if not completed. This way we get notified of stuck jobs with the already set up Slack integration.

Also updated the `build-archiving` jobs to properly name the produced artifacts with version and build number (`rescado_[version]-[build].{apk|ipa}`). Version and build is also shown in the download link.

![image](https://user-images.githubusercontent.com/3763638/148595033-692b78e3-93e8-4538-be71-623c8547266d.png)
