### PR TITLE
Firebase credentials on CI/CD

### DIFF
--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -2,7 +2,7 @@ name: Build archiving
 
 on:
   push:
-    branches: [ develop, hotfix/firebase-credentials-on-cicd ]
+    branches: [ develop ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -30,7 +30,7 @@ jobs:
           echo "Build number:   $GITHUB_RUN_NUMBER"
           echo "artifactVersion=$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
           # Make build
-          flutter build apk --release --build-number=$GITHUB_RUN_NUMBER
+          flutter build apk --release --build-number=$GITHUB_RUN_NUMBER --dart-define=androidFirebaseKey=$FIREBASE_KEY_ANDROID
           # Prepare artifact
           mkdir artifact
           mv build/app/outputs/flutter-apk/app-release.apk "artifact/rescado_$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER.apk"
@@ -71,7 +71,7 @@ jobs:
           echo "Build number:   $GITHUB_RUN_NUMBER"
           echo "artifactVersion=$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
           # Make build
-          flutter build ios --release --build-number=$GITHUB_RUN_NUMBER --no-codesign
+          flutter build ios --release --build-number=$GITHUB_RUN_NUMBER --dart-define=iosFirebaseKey=$FIREBASE_KEY_IOS --no-codesign
           # Prepare artifact
           mkdir -p artifact/Payload
           cp -r build/ios/iphoneos/Runner.app artifact/Payload

--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -2,14 +2,14 @@ name: Build archiving
 
 on:
   push:
-    branches: [ develop, hotfix/firebase-credentials-on-cicd ]
+    branches: [ develop ]
   workflow_dispatch:
 
 jobs:
   build-apk:
     name: Android build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -50,7 +50,7 @@ jobs:
   build-ipa:
     name: iOS build
     runs-on: macos-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -2,7 +2,7 @@ name: Build archiving
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, hotfix/firebase-credentials-on-cicd ]
   workflow_dispatch:
 
 jobs:
@@ -34,6 +34,8 @@ jobs:
           # Prepare artifact
           mkdir artifact
           mv build/app/outputs/flutter-apk/app-release.apk "artifact/rescado_$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER.apk"
+        env:
+          FIREBASE_KEY_ANDROID: ${{ secrets.FIREBASE_KEY_ANDROID }}
       - name: Archive Android application
         id: archive-android-app
         uses: actions/upload-artifact@v2.3.1
@@ -77,6 +79,8 @@ jobs:
           cp -r build/ios/iphoneos/Runner.app artifact/Payload
           cd artifact
           zip -r -y "rescado_$APP_VERSION_NUMBER-$GITHUB_RUN_NUMBER.ipa" Payload/Runner.app
+        env:
+          FIREBASE_KEY_IOS: ${{ secrets.FIREBASE_KEY_IOS }}
       - name: Archive iOS application
         id: archive-ios-app
         uses: actions/upload-artifact@v2.3.1

--- a/.github/workflows/build-archiving.yml
+++ b/.github/workflows/build-archiving.yml
@@ -2,7 +2,7 @@ name: Build archiving
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, hotfix/firebase-credentials-on-cicd ]
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@ Adopt, don't shop.
 
 ## Firebase setup
 
-`firebase_options.dart` is not included because it contains secrets, so you'll need to generate this file yourself.
+The Firebase API keys are not versioned,  so you will need to provide these as additional arguments when running/building. Each platform requires its key to be set, e.g. the iOS app runs fine without an `androidFirebaseKey` but it will crash if no `iosFirebaseKey` is provided.
+```shell
+flutter run \
+  --dart-define=iosFirebaseKey=$FIREBASE_KEY_IOS \
+  --dart-define=androidFirebaseKey=$FIREBASE_KEY_ANDROID
+```
+
+You can get these keys by logging into the Firebase Web Console and downloading the `google-services.json` and `GoogleService-Info.plist` for Android and iOS respectively, and look for the API key in there. Or, you can use the FlutterFire CLI to generate a temporary `firebase_options.dart` which will hold these keys as well.
 
 ```shell
 # Install Firebase CLI

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,11 +1,20 @@
 PODS:
   - device_info_plus (0.0.1):
     - Flutter
+  - Firebase/Analytics (8.10.0):
+    - Firebase/Core
+  - Firebase/Core (8.10.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (~> 8.10.0)
   - Firebase/CoreOnly (8.10.0):
     - FirebaseCore (= 8.10.0)
   - Firebase/Crashlytics (8.10.0):
     - Firebase/CoreOnly
     - FirebaseCrashlytics (~> 8.10.0)
+  - firebase_analytics (9.0.5):
+    - Firebase/Analytics (= 8.10.0)
+    - firebase_core
+    - Flutter
   - firebase_core (1.11.0):
     - Firebase/CoreOnly (= 8.10.0)
     - Flutter
@@ -13,6 +22,24 @@ PODS:
     - Firebase/Crashlytics (= 8.10.0)
     - firebase_core
     - Flutter
+  - FirebaseAnalytics (8.10.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.10.0)
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseAnalytics/AdIdSupport (8.10.0):
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleAppMeasurement (= 8.10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - nanopb (~> 2.30908.0)
   - FirebaseCore (8.10.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
@@ -37,14 +64,47 @@ PODS:
   - Flutter (1.0.0)
   - geolocator_apple (1.2.0):
     - Flutter
+  - GoogleAppMeasurement (8.10.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (8.10.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.10.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - nanopb (~> 2.30908.0)
   - GoogleDataTransport (9.1.2):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/AppDelegateSwizzler (7.7.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
   - GoogleUtilities/Environment (7.7.0):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (7.7.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (7.7.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
+  - GoogleUtilities/Reachability (7.7.0):
+    - GoogleUtilities/Logger
   - GoogleUtilities/UserDefaults (7.7.0):
     - GoogleUtilities/Logger
   - nanopb (2.30908.0):
@@ -60,6 +120,7 @@ PODS:
 
 DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
+  - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - Flutter (from `Flutter`)
@@ -70,10 +131,12 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Firebase
+    - FirebaseAnalytics
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseCrashlytics
     - FirebaseInstallations
+    - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
     - nanopb
@@ -82,6 +145,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
+  firebase_analytics:
+    :path: ".symlinks/plugins/firebase_analytics/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_crashlytics:
@@ -98,14 +163,17 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Firebase: 44213362f1dcc52555b935dc925ed35ac55f1b20
+  firebase_analytics: ab4a37ccfdc157e9fe43a2d47c230b39a405fbcc
   firebase_core: 2ca2d6cc8a11693e701b37126afae4800be5dbac
   firebase_crashlytics: 994376faf6e6acb76b9081ee0a00d8596038dc2b
+  FirebaseAnalytics: 319c9b3b1bdd400d60e2f415dff0c5f6959e6760
   FirebaseCore: 04186597c095da37d90ff9fd3e53bc61a1ff2440
   FirebaseCoreDiagnostics: 64d9709d804a6c25bd77841371c1fcfd909d5601
   FirebaseCrashlytics: 3b7f17cdf5bf1ae6ad5956696a6c26edeb39cca7
   FirebaseInstallations: 044eede8a049bce71c4541ee68d6e4364fcbe774
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   geolocator_apple: b741765c55dc21950e3e106e8b3584e55cf81ce5
+  GoogleAppMeasurement: a3311dbcf3ea651e5a070fe8559b57c174ada081
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,9 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Firebase setup
-  await Firebase.initializeApp(options: FirebaseConstants.currentPlatform);
+  await Firebase.initializeApp(
+    options: FirebaseConstants.currentPlatform,
+  );
 
   // Crashlytics setup
   await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(kDebugMode);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,16 +6,14 @@ import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logger/logger.dart';
-import 'package:rescado/firebase_options.dart'; // ignore: uri_does_not_exist
 import 'package:rescado/src/application.dart';
+import 'package:rescado/src/constants/firebase_constants.dart';
 
-Future<void> main() async {
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Firebase setup
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform, // ignore: argument_type_not_assignable, undefined_identifier
-  );
+  await Firebase.initializeApp(options: FirebaseConstants.currentPlatform);
 
   // Crashlytics setup
   await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(kDebugMode);

--- a/lib/src/constants/firebase_constants.dart
+++ b/lib/src/constants/firebase_constants.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
 import 'package:rescado/src/utils/logger.dart';
@@ -23,6 +25,7 @@ class FirebaseConstants {
 
     if (androidKey.isEmpty) {
       _logger.wtf('Missing Firebase API key for Android.');
+      exit(1);
     }
     return const FirebaseOptions(
       apiKey: androidKey,
@@ -38,6 +41,7 @@ class FirebaseConstants {
 
     if (iosKey.isEmpty) {
       _logger.wtf('Missing Firebase API key for iOS.');
+      exit(1);
     }
     return const FirebaseOptions(
       apiKey: iosKey,

--- a/lib/src/constants/firebase_constants.dart
+++ b/lib/src/constants/firebase_constants.dart
@@ -1,0 +1,36 @@
+import 'package:firebase_core/firebase_core.dart';
+
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
+
+class FirebaseConstants {
+  FirebaseConstants._();
+
+  static FirebaseOptions get currentPlatform {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      default:
+        throw UnsupportedError('Bad programming. Trying to set up Firebase on unsupported platform.');
+    }
+  }
+
+  static FirebaseOptions get android => const FirebaseOptions(
+        apiKey: String.fromEnvironment('androidFirebaseKey'),
+        appId: '1:761063297605:android:8f49e3e4300426141b092c',
+        messagingSenderId: '761063297605',
+        projectId: 'rescado-app',
+        storageBucket: 'rescado-app.appspot.com',
+      );
+
+  static FirebaseOptions get ios => const FirebaseOptions(
+        apiKey: String.fromEnvironment('iosFirebaseKey'),
+        appId: '1:761063297605:ios:60158da5236e7cb81b092c',
+        messagingSenderId: '761063297605',
+        projectId: 'rescado-app',
+        storageBucket: 'rescado-app.appspot.com',
+        iosClientId: '761063297605-psnfcf2b8kagmtk4pufta5tgnlea6ous.apps.googleusercontent.com',
+        iosBundleId: 'org.rescado.ios',
+      );
+}

--- a/lib/src/constants/firebase_constants.dart
+++ b/lib/src/constants/firebase_constants.dart
@@ -1,8 +1,10 @@
 import 'package:firebase_core/firebase_core.dart';
-
 import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
+import 'package:rescado/src/utils/logger.dart';
 
 class FirebaseConstants {
+  static final _logger = addLogger('FirebaseConstants');
+
   FirebaseConstants._();
 
   static FirebaseOptions get currentPlatform {
@@ -16,21 +18,35 @@ class FirebaseConstants {
     }
   }
 
-  static FirebaseOptions get android => const FirebaseOptions(
-        apiKey: String.fromEnvironment('androidFirebaseKey'),
-        appId: '1:761063297605:android:8f49e3e4300426141b092c',
-        messagingSenderId: '761063297605',
-        projectId: 'rescado-app',
-        storageBucket: 'rescado-app.appspot.com',
-      );
+  static FirebaseOptions get android {
+    const androidKey = String.fromEnvironment('androidFirebaseKey', defaultValue: '');
 
-  static FirebaseOptions get ios => const FirebaseOptions(
-        apiKey: String.fromEnvironment('iosFirebaseKey'),
-        appId: '1:761063297605:ios:60158da5236e7cb81b092c',
-        messagingSenderId: '761063297605',
-        projectId: 'rescado-app',
-        storageBucket: 'rescado-app.appspot.com',
-        iosClientId: '761063297605-psnfcf2b8kagmtk4pufta5tgnlea6ous.apps.googleusercontent.com',
-        iosBundleId: 'org.rescado.ios',
-      );
+    if (androidKey.isEmpty) {
+      _logger.wtf('Missing Firebase API key for Android.');
+    }
+    return const FirebaseOptions(
+      apiKey: androidKey,
+      appId: '1:761063297605:android:8f49e3e4300426141b092c',
+      messagingSenderId: '761063297605',
+      projectId: 'rescado-app',
+      storageBucket: 'rescado-app.appspot.com',
+    );
+  }
+
+  static FirebaseOptions get ios {
+    const iosKey = String.fromEnvironment('iosFirebaseKey', defaultValue: '');
+
+    if (iosKey.isEmpty) {
+      _logger.wtf('Missing Firebase API key for iOS.');
+    }
+    return const FirebaseOptions(
+      apiKey: iosKey,
+      appId: '1:761063297605:ios:60158da5236e7cb81b092c',
+      messagingSenderId: '761063297605',
+      projectId: 'rescado-app',
+      storageBucket: 'rescado-app.appspot.com',
+      iosBundleId: 'org.rescado.ios',
+      iosClientId: '761063297605-psnfcf2b8kagmtk4pufta5tgnlea6ous.apps.googleusercontent.com',
+    );
+  }
 }

--- a/lib/src/data/custom_theme.dart
+++ b/lib/src/data/custom_theme.dart
@@ -77,7 +77,7 @@ class CustomTheme {
       case CustomThemeIdentifier.dark:
         return CustomTheme.dark();
       default:
-        throw Exception('Bad programming. Not all identifiers were mapped.');
+        throw UnsupportedError('Bad programming. Not all identifiers were mapped.');
     }
   }
 

--- a/lib/src/utils/extensions.dart
+++ b/lib/src/utils/extensions.dart
@@ -12,7 +12,7 @@ extension UserStatusExtension on AccountStatus {
       case AccountStatus.blocked:
         return AuthenticationStatus.blocked;
       default:
-        throw Exception('Bad programming. Not all statuses were mapped.');
+        throw UnsupportedError('Bad programming. Not all statuses were mapped.');
     }
   }
 }


### PR DESCRIPTION
Should fix the build archiving job failing because it can't build the apps without Firebase API key. Keys will now be passed as arguments for `flutter run/build` which, for development, can easily be added to a run config in IntelliJ IDEA. 😊

Also upped timeout to 30 min because fetching pods can sometimes take a while for iOS builds.