### PR TITLE
Add underscroll to ClampingScrollPhysics

### DIFF
--- a/lib/src/utils/custom_clamping_scroll_physics.dart
+++ b/lib/src/utils/custom_clamping_scroll_physics.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+// Thank you https://github.com/flutter/flutter/issues/27977#issuecomment-464175636
+class CustomClampingScrollPhysics extends ClampingScrollPhysics {
+  const CustomClampingScrollPhysics({
+    ScrollPhysics? parent,
+    this.canUnderscroll = false,
+    this.canOverscroll = false,
+  }) : super(parent: parent);
+
+  final bool canUnderscroll;
+
+  final bool canOverscroll;
+
+  @override
+  CustomClampingScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return CustomClampingScrollPhysics(parent: buildParent(ancestor), canUnderscroll: canUnderscroll, canOverscroll: canOverscroll);
+  }
+
+  /// Removes the overscroll and underscroll conditions from the original
+  /// [ClampingScrollPhysics.applyBoundaryConditions].
+  @override
+  double applyBoundaryConditions(ScrollMetrics position, double value) {
+    if (value < position.pixels && position.pixels <= position.minScrollExtent) {
+      return canUnderscroll ? 0.0 : value - position.pixels;
+    }
+    if (position.maxScrollExtent <= position.pixels && position.pixels < value) {
+      return canOverscroll ? 0.0 : value - position.pixels;
+    }
+    if (value < position.minScrollExtent && position.minScrollExtent < position.pixels) {
+      return value - position.minScrollExtent;
+    }
+    if (position.pixels < position.maxScrollExtent && position.maxScrollExtent < value) {
+      return value - position.maxScrollExtent;
+    }
+    return 0.0;
+  }
+}

--- a/lib/src/views/profile_view.dart
+++ b/lib/src/views/profile_view.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:collection/collection.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -15,6 +17,7 @@ import 'package:rescado/src/services/controllers/match_controller.dart';
 import 'package:rescado/src/services/controllers/settings_controller.dart';
 import 'package:rescado/src/services/controllers/switch_controller.dart';
 import 'package:rescado/src/services/providers/device_data.dart';
+import 'package:rescado/src/utils/custom_clamping_scroll_physics.dart';
 import 'package:rescado/src/utils/extensions.dart';
 import 'package:rescado/src/views/buttons/action_button.dart';
 import 'package:rescado/src/views/buttons/appbar_button.dart';
@@ -245,6 +248,7 @@ class ProfileView extends ConsumerWidget {
   Widget _buildLikesPane({required BuildContext context, required WidgetRef ref}) => ref.watch(likeControllerProvider).when(
         data: (List<Like> likes) {
           return CustomScrollView(
+            physics: Platform.isAndroid ? const CustomClampingScrollPhysics(canUnderscroll: true) : const BouncingScrollPhysics(),
             slivers: <Widget>[
               CupertinoSliverRefreshControl(
                 onRefresh: () async {
@@ -300,6 +304,7 @@ class ProfileView extends ConsumerWidget {
             return ref.watch(matchControllerProvider).when(
                   data: (List<Like> likes) {
                     return CustomScrollView(
+                      physics: Platform.isAndroid ? const CustomClampingScrollPhysics(canUnderscroll: true) : const BouncingScrollPhysics(),
                       slivers: <Widget>[
                         CupertinoSliverRefreshControl(
                             onRefresh: () async {


### PR DESCRIPTION
As described [here](https://github.com/flutter/flutter/issues/27977#issuecomment-464175636), an implementation of `ClampingScrollPhysics` that allows underscroll so `CupertinoSliverRefreshControl` can do its thing..